### PR TITLE
Relax upper bounds on numpy and gymnasium to match upstream

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -21,8 +21,8 @@ requirements:
     - setuptools
   run:
     - python >={{ python_min }}
-    - gymnasium >=0.29.1,<1.1.0
-    - numpy >=1.20,<2.0
+    - gymnasium >=0.29.1,<1.3.0
+    - numpy >=1.20,<3.0
     - pytorch >=2.3,<3.0
     - cloudpickle
     - pandas


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I found that `stable-baselines3` conda packages are not installable alongside NumPy 2. I looked at the upstream package pinnings and it seems these can be relaxed.

See upstream pinnings:
https://github.com/DLR-RM/stable-baselines3/blob/8da3e5eadeda14c63f42c62dbbe7dbb00c2fd458/setup.py#L79-L80
